### PR TITLE
Should capture inserted text

### DIFF
--- a/src/SearchBox.elm
+++ b/src/SearchBox.elm
@@ -163,12 +163,7 @@ input userAttributes config =
             ]
     in
     Input.text (defaultAttributes ++ userAttributes)
-        { onChange =
-            if config.selected == Nothing then
-                config.onChange << TextChanged
-
-            else
-                config.onChange << always (TextChanged config.text)
+        { onChange = config.onChange << TextChanged
         , text =
             Maybe.map config.toLabel config.selected
                 |> Maybe.withDefault config.text


### PR DESCRIPTION
Problem
Selecting option from the options list. Clicking "Select All" (cmd + A) in the field and clicking any letter on the keyboard. Selection is cleared, but the first letter is not captured in the text field.

Solution
Capturing TextChanged event with entered text even if current selection exists. If developer does not clear the "selected" by themselves the label of "selected" is anyway shown.